### PR TITLE
ar -cr needed to not have duplicate symbols in the output static archive library file

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -32,7 +32,7 @@ install: $(APRILSAM_LIB)/libaprilsam.so
 
 $(APRILSAM_LIB)/libaprilsam.a: $(APRILSAM_OBJS)
 		@echo "   [$@]"
-		@$(AR) -cq $@ $(APRILSAM_OBJS)
+		@$(AR) -cr $@ $(APRILSAM_OBJS)
 
 $(APRILSAM_LIB)/libaprilsam.so: $(APRILSAM_OBJS)
 		@echo "   [$@]"


### PR DESCRIPTION
I was trying to build with the static library output libaprilsam.a, but was getting compiler errors about duplicate symbols. It seems that many symbols are all present in the various .o files, and then are duplicated when the archive file is put together, since the operation used is "ar -cq" with the "quick" appending symbols option. Changing the "q" to "r" for replacement of duplicate symbols (which is not a problem since there is only one version of all the libraries), fixed the issue for me!